### PR TITLE
adding EC2 djl rest prediction support for llama3 on fmbench

### DIFF
--- a/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
+++ b/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
@@ -167,7 +167,7 @@ experiments:
     model_id: # model id, version and image uri not needed for byo endpoint
     model_version:
     model_name: "llama3-8b-instruct"
-    # this can be changed to the IP address of a your specific EC2 instance where the model is hosted
+    # this can be changed to the IP address of your specific EC2 instance where the model is hosted
     ep_name: 'http://127.0.0.1/invocations' 
     instance_type: "g5.2xlarge"
     image_uri:

--- a/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
+++ b/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
@@ -1,7 +1,7 @@
 # config file for a rest endpoint supported on fmbench - 
 # this file uses a llama-3-8b-chat-hf deployed on ec2
 general:
-  name: "byo-ec2-REST-ep-llama3"      
+  name: "llama3-8b-g5.2xl-ec2"      
   model_name: "llama3-8b-instruct"
   
 # AWS and SageMaker settings
@@ -145,7 +145,7 @@ pricing: pricing.yml
 # Use the section name (sagemaker in this example) in the inference_spec.parameter_set
 # section under experiments.
 inference_parameters: 
-  ec2_djl_rest_set:
+  ec2_djl:
     do_sample: yes
     temperature: 0.1
     top_p: 0.92
@@ -167,8 +167,8 @@ experiments:
     model_id: # model id, version and image uri not needed for byo endpoint
     model_version:
     model_name: "llama3-8b-instruct"
-    # the ep_name will contain the endpoint url that is used to invoke your model and get the response
-    ep_name: 'http://<your-local-ec2-server>/invocations' 
+    # this can be changed to the IP address of a your specific EC2 instance where the model is hosted
+    ep_name: 'http://127.0.0.1/invocations' 
     instance_type: "g5.2xlarge"
     image_uri:
     deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
@@ -183,7 +183,7 @@ experiments:
     inference_script: ec2_djl_predictor.py
     inference_spec:
       # this should match one of the sections in the inference_parameters section above
-      parameter_set: ec2_djl_rest_set
+      parameter_set: ec2_djl
     # runs are done for each combination of payload file and concurrency level
     payload_files:
     - payload_en_1-500.jsonl
@@ -201,16 +201,13 @@ experiments:
     - 6
     - 8
     - 10 
-    - 12 
-    - 15
-    - 18
     # Environment variables to be passed to the container
     # this is not a fixed list, you can add more parameters as applicable.
     env:
 
 report:
-  latency_budget: 5
-  cost_per_10k_txn_budget: 50
+  latency_budget: 2
+  cost_per_10k_txn_budget: 20
   error_rate_budget: 0
   per_inference_request_file: per_inference_request_results.csv
   all_metrics_file: all_metrics.csv

--- a/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
+++ b/src/fmbench/configs/byoe/config-byo-ec2-rest-ep-llama3-8b.yml
@@ -1,0 +1,219 @@
+# config file for a rest endpoint supported on fmbench - 
+# this file uses a llama-3-8b-chat-hf deployed on ec2
+general:
+  name: "byo-ec2-REST-ep-llama3"      
+  model_name: "llama3-8b-instruct"
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  - 2wikimqa_e.jsonl
+  - 2wikimqa.jsonl
+  - hotpotqa_e.jsonl
+  - hotpotqa.jsonl
+  - narrativeqa.jsonl
+  - triviaqa_e.jsonl
+  - triviaqa.jsonl
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: llama3_tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_llama3.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: no
+  3_run_inference.ipynb: yes
+  4_model_metric_analysis.ipynb: yes
+  5_cleanup.ipynb: no
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 500
+    payload_file: payload_en_1-500.jsonl
+  - language: en
+    min_length_in_tokens: 500
+    max_length_in_tokens: 1000
+    payload_file: payload_en_500-1000.jsonl
+  - language: en
+    min_length_in_tokens: 1000
+    max_length_in_tokens: 2000
+    payload_file: payload_en_1000-2000.jsonl
+  - language: en
+    min_length_in_tokens: 2000
+    max_length_in_tokens: 3000
+    payload_file: payload_en_2000-3000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 4000
+    payload_file: payload_en_3000-4000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 3840
+    payload_file: payload_en_3000-3840.jsonl
+  - language: en
+    min_length_in_tokens: 1
+    max_length_in_tokens: 924
+    payload_file: payload_en_1-924.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_3000-3840
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  ec2_djl_rest_set:
+    do_sample: yes
+    temperature: 0.1
+    top_p: 0.92
+    top_k: 120  
+    max_new_tokens: 100
+    Content-type: application/json
+    return_full_text: False
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: "llama3-8b-instruct"
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    model_id: # model id, version and image uri not needed for byo endpoint
+    model_version:
+    model_name: "llama3-8b-instruct"
+    # the ep_name will contain the endpoint url that is used to invoke your model and get the response
+    ep_name: 'http://<your-local-ec2-server>/invocations' 
+    instance_type: "g5.2xlarge"
+    image_uri:
+    deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
+    # FMBench comes packaged with multiple deployment scripts, such as scripts for JumpStart
+    # scripts for deploying using DJL DeepSpeed, tensorRT etc. You can also add your own.
+    # See repo for details
+    instance_count: 
+    deployment_script: 
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example for a rest DJL predictor
+    # for a llama3-8b-instruct deployed on ec2
+    inference_script: ec2_djl_predictor.py
+    inference_spec:
+      # this should match one of the sections in the inference_parameters section above
+      parameter_set: ec2_djl_rest_set
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-500.jsonl
+    - payload_en_500-1000.jsonl
+    - payload_en_1000-2000.jsonl
+    - payload_en_2000-3000.jsonl
+    - payload_en_3000-3840.jsonl
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    - 2
+    - 4
+    - 6
+    - 8
+    - 10 
+    - 12 
+    - 15
+    - 18
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+
+report:
+  latency_budget: 5
+  cost_per_10k_txn_budget: 50
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025  

--- a/src/fmbench/configs/pricing.yml
+++ b/src/fmbench/configs/pricing.yml
@@ -5,7 +5,6 @@ pricing:
     ml.m5.xlarge: 0.23
     ml.g5.xlarge: 1.4084
     ml.g5.2xlarge: 1.515
-    g5.2xlarge: 1.212
     ml.g5.12xlarge: 7.09
     ml.g5.24xlarge: 10.18
     ml.g5.48xlarge: 20.36
@@ -24,6 +23,30 @@ pricing:
     ml.g6.24xlarge: 8.344
     ml.g6.48xlarge: 16.688
     anthropic.claude-v3-sonnet-pt-nc: 88
+    # corresponding hourly pricing for EC2 instances if your model is hosted on EC2
+    # all EC2 pricing is based on public on-demand pricing information that can be 
+    # viewed in this link: https://aws.amazon.com/ec2/pricing/on-demand/
+    m5.xlarge: 0.192
+    g5.xlarge: 1.006
+    g5.2xlarge: 1.212
+    g5.12xlarge: 5.672
+    g5.24xlarge: 8.144
+    g5.48xlarge: 16.288
+    inf2.xlarge: 0.7582
+    inf2.8xlarge: 1.96786
+    inf2.24xlarge: 6.49063
+    inf2.48xlarge: 12.98127
+    trn1.32xlarge: 21.50
+    p4d.24xlarge: 32.7726
+    p5.48xlarge: 98.32
+    p3.2xlarge: 3.06
+    g4dn.12xlarge: 3.912
+    g6.2xlarge: 0.9776
+    g6.16xlarge: 3.3968
+    g6.12xlarge: 4.6016
+    g6.24xlarge: 6.6752
+    g6.48xlarge: 13.3504
+
 
   token_based:
     # Token Based Pricing: Bedrock

--- a/src/fmbench/configs/pricing.yml
+++ b/src/fmbench/configs/pricing.yml
@@ -5,6 +5,7 @@ pricing:
     ml.m5.xlarge: 0.23
     ml.g5.xlarge: 1.4084
     ml.g5.2xlarge: 1.515
+    g5.2xlarge: 1.212
     ml.g5.12xlarge: 7.09
     ml.g5.24xlarge: 10.18
     ml.g5.48xlarge: 20.36

--- a/src/fmbench/scripts/ec2_djl_predictor.py
+++ b/src/fmbench/scripts/ec2_djl_predictor.py
@@ -11,12 +11,12 @@ from fmbench.utils import count_tokens
 from typing import Dict, Optional, List
 from fmbench.scripts.fmbench_predictor import (FMBenchPredictor,
                                                FMBenchPredictionResponse)
-                                               
+                                            
 # set a logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-class RESTPredictor(FMBenchPredictor):
+class EC2Predictor(FMBenchPredictor):
     # overriding abstract method
     def __init__(self,
                  endpoint_name: str,
@@ -106,4 +106,4 @@ class RESTPredictor(FMBenchPredictor):
         return self._inference_spec.get("parameters")
 
 def create_predictor(endpoint_name: str, inference_spec: Optional[Dict]):
-    return RESTPredictor(endpoint_name, inference_spec)
+    return EC2Predictor(endpoint_name, inference_spec)

--- a/src/fmbench/scripts/ec2_djl_predictor.py
+++ b/src/fmbench/scripts/ec2_djl_predictor.py
@@ -1,0 +1,109 @@
+import os
+import json
+import math
+import time
+import boto3
+import logging
+import requests
+import pandas as pd
+from datetime import datetime
+from fmbench.utils import count_tokens
+from typing import Dict, Optional, List
+from fmbench.scripts.fmbench_predictor import (FMBenchPredictor,
+                                               FMBenchPredictionResponse)
+                                               
+# set a logger
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class RESTPredictor(FMBenchPredictor):
+    # overriding abstract method
+    def __init__(self,
+                 endpoint_name: str,
+                 inference_spec: Optional[Dict]):
+        try:
+            self._endpoint_name: str = endpoint_name
+            self._inference_spec: Dict = inference_spec 
+        except Exception as e:
+            logger.error(f"create_predictor, exception occured while creating predictor "
+                         f"for endpoint_name={self._endpoint_name}, exception={e}")
+        logger.info(f"_endpoint_name={self._endpoint_name}, _inference_spec={self._inference_spec}")
+
+    def get_prediction(self, payload: Dict) -> FMBenchPredictionResponse:
+        response_json: Optional[Dict] = None
+        response: Optional[str] = None
+        latency: Optional[float] = None
+        prompt_tokens: Optional[int] = None
+        completion_tokens: Optional[int] = None
+        # get the prompt for the EKS endpoint
+        prompt: str = payload['inputs']
+        # represents the number of tokens in the prompt payload
+        prompt_tokens = count_tokens(payload['inputs'])
+        try:
+            st = time.perf_counter()
+            split_input_and_inference_params: Optional[bool] = None
+            if self._inference_spec is not None:
+                split_input_and_inference_params = self._inference_spec.get("split_input_and_parameters")
+                logger.info(f"split input parameters is: {split_input_and_inference_params}")
+            # this is the POST request to the endpoint url for invocations that 
+            # is given to you as you deploy a model on EC2 using the DJL serving stack
+            response = requests.post(self._endpoint_name, payload) 
+            # record the latency for the response generated
+            latency = time.perf_counter() - st
+            # For other response types, change the logic below and add the response in the `generated_text` key within the response_json dict
+            response.raise_for_status()
+            full_output = response.text
+            answer_only = full_output.replace(prompt, "", 1).strip('["]?\n')
+            response_json = dict(generated_text=answer_only)
+            # counts the completion tokens for the model using the default/user provided tokenizer
+            completion_tokens = count_tokens(response_json.get("generated_text"))
+        except requests.exceptions.RequestException as e:
+            logger.error(f"get_prediction, exception occurred while getting prediction for payload={payload} "
+                         f"from predictor={self._endpoint_name}, response={response}, exception={e}")
+        return FMBenchPredictionResponse(response_json=response_json,
+                                         latency=latency,
+                                         completion_tokens=completion_tokens,
+                                         prompt_tokens=prompt_tokens)
+
+    @property
+    def endpoint_name(self) -> str:
+        """The endpoint name property."""
+        return self._endpoint_name
+
+    # The rest ep is deployed on an instance that incurs hourly cost hence, the calculcate cost function
+    # computes the cost of the experiment on an hourly basis. If your instance has a different pricing structure
+    # modify this function.
+    def calculate_cost(self,
+                       instance_type: str,
+                       instance_count: int,
+                       pricing: Dict,
+                       duration: float,
+                       prompt_tokens: int,
+                       completion_tokens: int) -> float:
+        """Calculate the cost of each experiment run."""
+        experiment_cost: Optional[float] = None
+        try:
+            instance_based_pricing = pricing['pricing']['instance_based']
+            hourly_rate = instance_based_pricing.get(instance_type, None)
+            logger.info(f"the hourly rate for running on {instance_type} is {hourly_rate}, instance_count={instance_count}")
+            # calculating the experiment cost for instance based pricing
+            instance_count = instance_count if instance_count else 1
+            experiment_cost = (hourly_rate / 3600) * duration * instance_count
+        except Exception as e:
+            logger.error(f"exception occurred during experiment cost calculation, exception={e}")
+        return experiment_cost
+    
+    def get_metrics(self,
+                    start_time: datetime,
+                    end_time: datetime,
+                    period: int = 60) -> pd.DataFrame:
+        # not implemented
+        return None
+
+    @property
+    def inference_parameters(self) -> Dict:
+        """The inference parameters property."""
+        return self._inference_spec.get("parameters")
+
+def create_predictor(endpoint_name: str, inference_spec: Optional[Dict]):
+    return RESTPredictor(endpoint_name, inference_spec)

--- a/src/fmbench/scripts/ec2_djl_predictor.py
+++ b/src/fmbench/scripts/ec2_djl_predictor.py
@@ -20,10 +20,11 @@ class EC2Predictor(FMBenchPredictor):
     # overriding abstract method
     def __init__(self,
                  endpoint_name: str,
-                 inference_spec: Optional[Dict]):
+                 inference_spec: Optional[Dict], 
+                 metadata: Optional[Dict]):
         try:
             self._endpoint_name: str = endpoint_name
-            self._inference_spec: Dict = inference_spec 
+            self._inference_spec: Dict = inference_spec
         except Exception as e:
             logger.error(f"create_predictor, exception occured while creating predictor "
                          f"for endpoint_name={self._endpoint_name}, exception={e}")
@@ -105,5 +106,5 @@ class EC2Predictor(FMBenchPredictor):
         """The inference parameters property."""
         return self._inference_spec.get("parameters")
 
-def create_predictor(endpoint_name: str, inference_spec: Optional[Dict]):
-    return EC2Predictor(endpoint_name, inference_spec)
+def create_predictor(endpoint_name: str, inference_spec: Optional[Dict], metadata: Optional[Dict]):
+    return EC2Predictor(endpoint_name, inference_spec, metadata)


### PR DESCRIPTION
This PR contains:

1. updated pricing.yml file with the ec2 g5.2xl pricing addition
2. ec2_djl_predictor to handle post requests to the ep url
3. new llama3 on ec2 byoe (more like bring your endpoint url :) ) config file