### PR TITLE
cloudformation template generalized for gov cloud

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -17,9 +17,16 @@ Parameters:
     MaxLength: 63
     AllowedPattern: (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
 
+Conditions:
+  IsGovCloudPartition: !Equals
+    - !Select [0, !Split [ "aws-us-gov", !Ref "AWS::Partition"]]
+    - ""
+  IsNotGovCloud: !Not [ !Condition IsGovCloudPartition ]
+
 Resources:
   CodeRepository:
     Type: AWS::SageMaker::CodeRepository
+    Condition: IsNotGovCloud
     Properties:
       GitConfig:
         RepositoryUrl: https://github.com/aws-samples/foundation-model-benchmarking-tool
@@ -30,7 +37,7 @@ Resources:
       NotebookInstanceName: !Sub ${AWS::StackName}-notebook
       InstanceType: ml.m6i.xlarge
       RoleArn: !GetAtt NotebookRole.Arn
-      DefaultCodeRepository: !GetAtt CodeRepository.CodeRepositoryName
+      DefaultCodeRepository: !If [ IsNotGovCloud, !GetAtt CodeRepository.CodeRepositoryName, !Ref "AWS::NoValue" ]
 
   NotebookRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
This PR contains the following changes:

1. Condition addition in template.yml to support gov cloud CFT stack deployments. If the partition is in aws-us-gov, the github repository will not be cloned to the SM notebook instance
2. If the region is anywhere out of the gov cloud, the github repository will by default be cloned within the SM notebook instance
3. This template is successfully tested with titan on bedrock in gov cloud as well as llama2-7b quick in a general us-east-1 region

To Do:
1. Need to create a new build with this template to handle the .keep error 
3. update the launch stack button template using this new cft template