### PR TITLE
Add Material for Mkdocs Config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+site_name: Foundation Model Benchmarking Tools
+repo_name: aws-samples/foundation-model-benchmarking-tool
+repo_url: https://github.com/aws-samples/foundation-model-benchmarking-tool
+edit_uri: https://github.com/aws-samples/foundation-model-benchmarking-tool/edit/master/
+site_url: https://foundation-model-benchmarking-tool.github.io
+use_directory_urls: false
+markdown_extensions:
+  - codehilite
+  - toc:
+      permalink: true
+theme:
+  name: material
+  logo: website/img/DJL.svg
+  favicon: website/img/favicon.png
+  features:
+    - navigation
+  palette:
+      - scheme: default
+        primary: light-blue
+        accent: light-blue
+        toggle:
+            icon: material/weather-sunny
+            name: Switch to dark mode
+      - scheme: slate
+        primary: black
+        accent: deep-orange
+        toggle:
+            icon: material/weather-night
+            name: Switch to light mode
+  edit_uri: ''
+
+extra:
+  social:
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/aws-samples/foundation-model-benchmarking-tool
+    - icon: fontawesome/brands/slack
+      link: https://github.com/aws-samples/foundation-model-benchmarking-tool
+plugins:
+  - search
+  - mknotebooks
+
+nav: 
+  - 'overview.md'
+  - 'report.md'


### PR DESCRIPTION
Description:

This pull request adds the configuration for Material for MkDocs to the project. Material for MkDocs is a theme for MkDocs, an open-source project that generates static site documentation. This update will enhance the documentation's appearance and usability.

Changes Made:

- Added mkdocs-material to the project's dependencies.
- Updated mkdocs.yml configuration file to use Material theme.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
