### PR TITLE
remove unecessary --runtime=nvidia from the docker command

### DIFF
--- a/src/fmbench/configs/llama3/70b/config-ec2-llama3-70b-instruct.yml
+++ b/src/fmbench/configs/llama3/70b/config-ec2-llama3-70b-instruct.yml
@@ -190,7 +190,7 @@ experiments:
       # '--runtime=nvidia' tells the container runtime to use the NVIDIA runtime
       # '--gpus all' makes all GPUs available to the container
       # '--shm-size 12g' sets the size of the shared memory to 24 gigabytes
-      gpu_or_neuron_setting: --runtime=nvidia --gpus all --shm-size 24g
+      gpu_or_neuron_setting: --gpus all --shm-size 24g
       #This setting specifies the timeout (in seconds) for loading the model. In this case, the timeout is set to 2400 seconds, which is 40 minutes. 
       # If the model takes longer than 40 minutes to load, the process will time out and fail.
       model_loading_timeout: 7200

--- a/src/fmbench/configs/llama3/8b/config-ec2-llama3-8b.yml
+++ b/src/fmbench/configs/llama3/8b/config-ec2-llama3-8b.yml
@@ -187,7 +187,7 @@ experiments:
       # '--runtime=nvidia' tells the container runtime to use the NVIDIA runtime
       # '--gpus all' makes all GPUs available to the container
       # '--shm-size 12g' sets the size of the shared memory to 12 gigabytes
-      gpu_or_neuron_setting: --runtime=nvidia --gpus all --shm-size 12g
+      gpu_or_neuron_setting: --gpus all --shm-size 12g
       #This setting specifies the timeout (in seconds) for loading the model. In this case, the timeout is set to 2400 seconds, which is 40 minutes. 
       # If the model takes longer than 40 minutes to load, the process will time out and fail.
       model_loading_timeout: 2400


### PR DESCRIPTION
Changes in this PR:

1. The model is deployed without using the --runtime=nvidia parameter in the command
2. Removing this in two configuration files