### PR TITLE
Add Support for Metrics While Benchmarking on Neuron and EC2

### DIFF
--- a/src/fmbench/configs/llama3/8b/config-ec2-llama3-8b-m7i-12xlarge.yml
+++ b/src/fmbench/configs/llama3/8b/config-ec2-llama3-8b-m7i-12xlarge.yml
@@ -1,0 +1,226 @@
+# config file for a rest endpoint supported on fmbench - 
+# this file uses a llama-3-8b-chat-hf deployed on ec2
+general:
+  name: "llama3-8b-m7i.12xl-ec2"      
+  model_name: "llama3-8b-instruct"
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  - 2wikimqa_e.jsonl
+  - 2wikimqa.jsonl
+  - hotpotqa_e.jsonl
+  - hotpotqa.jsonl
+  - narrativeqa.jsonl
+  - triviaqa_e.jsonl
+  - triviaqa.jsonl
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: llama3_tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_llama3.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: yes
+  3_run_inference.ipynb: yes
+  4_model_metric_analysis.ipynb: yes
+  5_cleanup.ipynb: yes
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 500
+    payload_file: payload_en_1-500.jsonl
+  - language: en
+    min_length_in_tokens: 500
+    max_length_in_tokens: 1000
+    payload_file: payload_en_500-1000.jsonl
+  - language: en
+    min_length_in_tokens: 1000
+    max_length_in_tokens: 2000
+    payload_file: payload_en_1000-2000.jsonl
+  - language: en
+    min_length_in_tokens: 2000
+    max_length_in_tokens: 3000
+    payload_file: payload_en_2000-3000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 3840
+    payload_file: payload_en_3000-3840.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_3000-3840
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  ec2_vllm:
+    model: meta-llama/Meta-Llama-3-8B-Instruct
+    temperature: 0.1
+    top_p: 0.92
+    top_k: 120  
+    max_tokens: 100
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: "llama3-8b-instruct"
+    # AWS region, this parameter is templatized, no need to change
+    region: {region}
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    #from huggingface to grab
+    model_id: meta-llama/Meta-Llama-3-8B-Instruct # model id, version and image uri not needed for byo endpoint
+    model_version:
+    model_name: "llama3-8b-instruct"
+    # this can be changed to the IP address of your specific EC2 instance where the model is hosted
+    ep_name: 'http://localhost:8000/v1/completions' 
+    instance_type: "m7i.12xlarge"
+    image_uri: vllm-cpu-env
+    deploy: yes #setting to yes to run deployment script for ec2
+    instance_count: 
+    deployment_script: ec2_deploy.py
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example for a rest DJL predictor
+    # for a llama3-8b-instruct deployed on ec2
+    inference_script: ec2_predictor.py
+    # This section defines the settings for Amazon EC2 instances
+    ec2:
+      # Privileged Mode makes the docker container run with root. 
+      # This basically means that if you are root in a container you have the privileges of root on the host system
+      # Only need this if you need to set VLLM_CPU_OMP_THREADS_BIND env variable.
+      privileged_mode: yes      
+      # The following line specifies the runtime and GPU settings for the instance
+      # '--runtime=nvidia' tells the container runtime to use the NVIDIA runtime
+      # '--gpus all' makes all GPUs available to the container
+      # '--shm-size 12g' sets the size of the shared memory to 12 gigabytes
+      gpu_or_neuron_setting:
+      # This setting specifies the timeout (in seconds) for loading the model. In this case, the timeout is set to 2400 seconds, which is 40 minutes. 
+      # If the model takes longer than 40 minutes to load, the process will time out and fail.
+      model_loading_timeout: 2400
+    inference_spec:
+      # this should match one of the sections in the inference_parameters section above
+      parameter_set: ec2_vllm
+      # if not set assume djl
+      container_type: vllm
+    # modify the serving properties to match your model and requirements
+    serving.properties:
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-500.jsonl
+    - payload_en_500-1000.jsonl
+    - payload_en_1000-2000.jsonl
+    - payload_en_2000-3000.jsonl
+    - payload_en_3000-3840.jsonl
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    # - 2
+    # - 4
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+      VLLM_CPU_KVCACHE_SPACE: 40
+      # This instance has 48 CPUs, and we are allocating 40 of them to run this container.
+      # For more information, visit the following URL:
+      # https://docs.vllm.ai/en/latest/getting_started/cpu-installation.html#related-runtime-environment-variables
+      VLLM_CPU_OMP_THREADS_BIND: 0-40
+
+report:
+  latency_budget: 25
+  cost_per_10k_txn_budget: 20
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025  

--- a/src/fmbench/configs/pricing.yml
+++ b/src/fmbench/configs/pricing.yml
@@ -3,8 +3,6 @@ pricing:
     # Instance Based Pricing: SageMaker, EKS, Bedrock Provisioned Throughput, Bring your own endpoints that are priced hourly
     # SageMaker Hourly Instance Pricing
     ml.m5.xlarge: 0.23
-    m5.16xlarge: 3.072
-    c5.18xlarge: 3.06
     ml.g5.xlarge: 1.4084
     ml.g5.2xlarge: 1.515
     ml.g5.12xlarge: 7.09
@@ -24,12 +22,16 @@ pricing:
     ml.g6.12xlarge: 5.752
     ml.g6.24xlarge: 8.344
     ml.g6.48xlarge: 16.688
-    m7a.4xlarge: 0.9274
-    m7a.16xlarge: 3.709
     anthropic.claude-v3-sonnet-pt-nc: 88
     # corresponding hourly pricing for EC2 instances if your model is hosted on EC2
     # all EC2 pricing is based on public on-demand pricing information that can be 
     # viewed in this link: https://aws.amazon.com/ec2/pricing/on-demand/
+    m5.16xlarge: 3.072
+    c5.18xlarge: 3.06
+    m7i.12xlarge: 2.419
+    m7a.4xlarge: 0.9274
+    m7a.16xlarge: 3.709
+    m7a.24xlarge: 5.564
     m5.xlarge: 0.192
     g5.xlarge: 1.006
     g5.2xlarge: 1.212

--- a/src/fmbench/scripts/ec2_metrics.py
+++ b/src/fmbench/scripts/ec2_metrics.py
@@ -1,0 +1,183 @@
+"""
+Collects and logs GPU and CPU metrics to a CSV file.
+"""
+
+
+# Need to install these 2 dependencies:
+# pip install psutil==5.9.8
+# pip install nvitop==1.3.2
+
+import csv
+import time
+import psutil
+import logging
+from nvitop import Device, ResourceMetricCollector
+
+
+# Setup logging
+logging.basicConfig(
+    format="[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+csv_file_name = "EC2_system_metrics.csv"
+
+# Global flag to control data collection for now, change in future.
+collecting = True
+
+
+def stop_collect(collector=None):
+    """
+    Stops the data collection process by setting the global flag 'collecting' to False.
+    """
+    global collecting
+    collecting = False
+    logger.info("Stopped collection")
+
+
+def _collect_ec2_utilization_metrics():
+    """
+    Starts the data collection process by initializing the ResourceMetricCollector and collecting metrics at regular intervals.
+    """
+    global collecting
+    logger.info("Starting collection")
+
+    def on_collect(metrics):
+        """
+        Collects GPU and CPU metrics, then appends them to the CSV file.
+
+        Parameters:
+        - metrics: The collected metrics from the ResourceMetricCollector.
+
+        Returns:
+        - bool: Returns False if the collection is stopped, otherwise True.
+        """
+        if not collecting:
+            return False
+
+        try:
+            # Open the CSV file in append mode and write the collected metrics
+            with open(csv_file_name, mode="a", newline="") as csv_file:
+                csv_writer = csv.writer(csv_file)
+
+                # Collect CPU mean utilization
+                cpu_percent_mean = metrics.get(
+                    "metrics-daemon/host/cpu_percent (%)/mean", psutil.cpu_percent()
+                )
+                memory_percent_mean = metrics.get(
+                    "metrics-daemon/host/memory_percent (%)/mean",
+                    psutil.virtual_memory().percent,
+                )
+                memory_used_mean = metrics.get(
+                    "metrics-daemon/host/memory_used (GiB)/mean",
+                    psutil.virtual_memory().available,
+                )
+
+                # Extract the current timestamp
+                timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+
+                # Initialize variables to sum GPU metrics
+                total_gpu_utilization = 0
+                total_gpu_memory_used = 0
+                total_gpu_memory_free = 0
+                total_gpu_memory_total = 0
+
+                num_gpus = len(Device.cuda.all())
+                # logger.info(f"Number of GPUs detected: {num_gpus}")
+
+                # Iterate over all detected GPUs
+                for gpu_id in range(num_gpus):
+                    gpu_utilization_mean = metrics.get(
+                        f"metrics-daemon/cuda:{gpu_id} (gpu:{gpu_id})/gpu_utilization (%)/mean",
+                        None,
+                    )
+                    gpu_memory_used_mean = metrics.get(
+                        f"metrics-daemon/cuda:{gpu_id} (gpu:{gpu_id})/memory_used (MiB)/mean",
+                        None,
+                    )
+                    gpu_memory_free_mean = metrics.get(
+                        f"metrics-daemon/cuda:{gpu_id} (gpu:{gpu_id})/memory_free (MiB)/mean",
+                        None,
+                    )
+                    gpu_memory_total_mean = metrics.get(
+                        f"metrics-daemon/cuda:{gpu_id} (gpu:{gpu_id})/memory_total (MiB)/mean",
+                        None,
+                    )
+
+                    if gpu_utilization_mean is not None:
+                        total_gpu_utilization += gpu_utilization_mean
+                    if gpu_memory_used_mean is not None:
+                        total_gpu_memory_used += gpu_memory_used_mean
+                    if gpu_memory_free_mean is not None:
+                        total_gpu_memory_free += gpu_memory_free_mean
+                    if gpu_memory_total_mean is not None:
+                        total_gpu_memory_total += gpu_memory_total_mean
+
+                # Calculate the mean values across all GPUs
+                gpu_utilization_mean_total = (
+                    total_gpu_utilization / num_gpus if num_gpus > 0 else None
+                )
+                gpu_memory_used_mean_total = (
+                    total_gpu_memory_used / num_gpus if num_gpus > 0 else None
+                )
+                gpu_memory_free_mean_total = (
+                    total_gpu_memory_free / num_gpus if num_gpus > 0 else None
+                )
+                gpu_memory_total_mean_total = (
+                    total_gpu_memory_total / num_gpus if num_gpus > 0 else None
+                )
+
+                # Write the row to the CSV file
+                row = [
+                    timestamp,
+                    cpu_percent_mean,
+                    memory_percent_mean,
+                    memory_used_mean,
+                    gpu_utilization_mean_total,  # Mean utilization out of n gpus%, example if there are 4 gpus, it is out of 400%
+                    gpu_memory_used_mean_total,
+                    gpu_memory_free_mean_total,
+                    gpu_memory_total_mean_total,
+                ]
+                # logger.info(f"Writing row: {row}")
+                csv_writer.writerow(row)
+
+        except ValueError as e:
+            return False
+
+        return True
+
+    # Start the collector and run in the background
+    collector = ResourceMetricCollector(Device.cuda.all())
+    logger.info("Starting Daemon collector to run in background")
+    collector.daemonize(
+        on_collect,
+        interval=5,
+        on_stop=stop_collect,  # Adjust the interval as needed in seconds
+    )
+
+
+def collect_ec2_metrics():
+    """
+    Initializes the CSV file with headers and starts the metrics collection process.
+    """
+    global collecting
+    collecting = True
+    # Initialize the CSV file and write the header once
+    with open(csv_file_name, mode="w", newline="") as csv_file:
+        csv_writer = csv.writer(csv_file)
+        header = [
+            "timestamp",
+            "cpu_percent_mean",
+            "memory_percent_mean",
+            "memory_used_mean",
+            "gpu_utilization_mean",
+            "gpu_memory_used_mean",
+            "gpu_memory_free_mean",
+            "gpu_memory_total_mean",
+        ]
+        logger.info(f"Writing header: {header}")
+        csv_writer.writerow(header)
+
+    # Call the function to start collecting metrics
+    _collect_ec2_utilization_metrics()

--- a/src/fmbench/scripts/neuron_metrics.py
+++ b/src/fmbench/scripts/neuron_metrics.py
@@ -7,8 +7,8 @@ from threading import Thread
 
 # Setup logging
 logging.basicConfig(
-    format='[%(asctime)s] %(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s',
-    level=logging.INFO
+    format="[%(asctime)s] %(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+    level=logging.INFO,
 )
 logger = logging.getLogger(__name__)
 
@@ -17,25 +17,32 @@ data_collection = []
 stop_collecting = False
 collection_thread = None
 
+
 def _collect_data(shell_command):
     global data_collection, stop_collecting
     logger.info(f"Starting data collection using command: {shell_command}")
 
-    with subprocess.Popen(shell_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+    with subprocess.Popen(
+        shell_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as proc:
         try:
             while not stop_collecting:
                 output = proc.stdout.readline()
-                if output == b'' and proc.poll() is not None:
+                if output == b"" and proc.poll() is not None:
                     break
                 if output:
-                    json_data = json.loads(output.decode('utf-8'))
+                    json_data = json.loads(output.decode("utf-8"))
 
                     # Extract system data
                     system_data = json_data.get("system_data", {})
-                    vcpu_usage = system_data.get("vcpu_usage", {}).get("average_usage", {})
+                    vcpu_usage = system_data.get("vcpu_usage", {}).get(
+                        "average_usage", {}
+                    )
                     memory_info = system_data.get("memory_info", {})
-                    
-                    memory_total_gb = memory_info.get("memory_total_bytes", 0) / (1024**3)
+
+                    memory_total_gb = memory_info.get("memory_total_bytes", 0) / (
+                        1024**3
+                    )
                     memory_used_gb = memory_info.get("memory_used_bytes", 0) / (1024**3)
                     swap_total_gb = memory_info.get("swap_total_bytes", 0) / (1024**3)
                     swap_used_gb = memory_info.get("swap_used_bytes", 0) / (1024**3)
@@ -45,8 +52,10 @@ def _collect_data(shell_command):
                     for runtime_entry in neuron_runtime_data:
                         report = runtime_entry.get("report", {})
                         neuroncore_counters = report.get("neuroncore_counters", {})
-                        neuron_cores_in_use = neuroncore_counters.get("neuroncores_in_use", {})
-                        
+                        neuron_cores_in_use = neuroncore_counters.get(
+                            "neuroncores_in_use", {}
+                        )
+
                         neuron_utilization = {}
                         total_utilization = 0
                         neuroncore_count = 0
@@ -54,9 +63,13 @@ def _collect_data(shell_command):
                         # Calculate the total utilization and count the number of NeuronCores
                         for core_index, core_data in neuron_cores_in_use.items():
                             utilization = core_data.get("neuroncore_utilization", 0)
-                            neuron_utilization[f"neuroncore_{core_index}_utilization"] = utilization
-                            neuron_utilization[f"neuroncore_{core_index}_flops"] = core_data.get("flops", None)
-                            
+                            neuron_utilization[
+                                f"neuroncore_{core_index}_utilization"
+                            ] = utilization
+                            neuron_utilization[f"neuroncore_{core_index}_flops"] = (
+                                core_data.get("flops", None)
+                            )
+
                             if utilization is not None:
                                 total_utilization += utilization
                                 neuroncore_count += 1
@@ -78,7 +91,8 @@ def _collect_data(shell_command):
                             "neuroncore_count": neuroncore_count,
                             "total_neuroncore_utilization": total_utilization,
                             "mean_neuroncore_utilization_percentage": mean_utilization,
-                            "mean_neuroncore_utilization_total_possible": mean_utilization * neuroncore_count  # out of 100% * number of cores
+                            "mean_neuroncore_utilization_total_possible": mean_utilization
+                            * neuroncore_count,  # out of 100% * number of cores
                         }
 
                         # Merge neuron utilization data into the flattened_data
@@ -92,6 +106,7 @@ def _collect_data(shell_command):
             proc.terminate()
             logger.info("Data collection process terminated.")
 
+
 def start_collection(shell_command):
     """Starts the data collection in a separate thread."""
     global stop_collecting, collection_thread
@@ -99,6 +114,7 @@ def start_collection(shell_command):
     collection_thread = Thread(target=_collect_data, args=(shell_command,))
     collection_thread.start()
     logger.info("Data collection started in the background.")
+
 
 def stop_collection():
     """Stops the data collection."""
@@ -108,11 +124,13 @@ def stop_collection():
         collection_thread.join()
     logger.info("Data collection stopped.")
 
+
 def get_collected_data():
     """Returns the collected data as a Pandas DataFrame."""
     global data_collection
     logger.info(f"Returning collected data with {len(data_collection)} records.")
     return pd.DataFrame(data_collection)
+
 
 def reset_collection():
     """Resets the collected data and state."""
@@ -121,4 +139,3 @@ def reset_collection():
     stop_collecting = False
     collection_thread = None
     logger.info("Data collection has been reset.")
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR introduces the ability to collect system metrics (CPU, memory, Neuron utilization) during benchmarking on EC2 instances and during benchmarking on AWS Neuron. These metrics provide deeper insight into performance during the benchmarking process and can help optimize workloads for EC2/Neuron.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
