### PR TITLE
Add `hf_model_id` config param

### DIFF
--- a/src/fmbench/configs/llama3.1/8b/config-llama3.1-8b-g5.2xl-tp-1-mc-max-ec2.yml
+++ b/src/fmbench/configs/llama3.1/8b/config-llama3.1-8b-g5.2xl-tp-1-mc-max-ec2.yml
@@ -159,6 +159,7 @@ experiments:
     # see the DJL serving deployment script in the code repo for reference. 
     #from huggingface to grab
     model_id: meta-llama/Llama-3.1-8B-Instruct # model id, version and image uri not needed for byo endpoint
+    hf_model_id: meta-llama/Llama-3.1-8B-Instruct
     model_version:
     model_name: "Llama-3.1-8B-Instruct"
     # this can be changed to the IP address of your specific EC2 instance where the model is hosted

--- a/src/fmbench/globals.py
+++ b/src/fmbench/globals.py
@@ -223,6 +223,7 @@ TOKENIZER = 'tokenizer'
 # NOTE: if tokenizer files are provided in the tokenizer directory then they take precedence
 # if the files are not present then we load the tokenizer for this model id from Hugging Face
 TOKENIZER_MODEL_ID = config['experiments'][0].get('model_id')
+HF_TOKENIZER_MODEL_ID = config['experiments'][0].get('hf_model_id')
 
 DEPLOYMENT_SCRIPT_S3 = config['s3_read_data']['scripts_prefix']
 

--- a/src/fmbench/utils.py
+++ b/src/fmbench/utils.py
@@ -444,7 +444,7 @@ class CustomTokenizer:
     else:
         print(f"{HF_TOKEN_FNAME} file not found")
 
-    def __init__(self, bucket, prefix, local_dir, model_id):
+    def __init__(self, bucket, prefix, local_dir, model_id, hf_model_id=None):
         print(f"CustomTokenizer, based on HF transformers, {bucket} "
               f"prefix: {prefix} local_dir: {local_dir}, model_id: {model_id}")
         # Check if the tokenizer files exist in s3 and if not, use the autotokenizer
@@ -461,11 +461,17 @@ class CustomTokenizer:
         else:
             print(f"{local_dir} directory is empty")
             try:
-                print(f"going to download tokenizer from HF for \"{model_id}\"")
-                self.tokenizer = AutoTokenizer.from_pretrained(model_id)
-                print(f"successfully loaded the tokenizer using AutoTokenizer.from_pretrained from HF for \"{model_id}\"")
+                if hf_model_id:
+                    print(f"HF TOKEN ID provided, Overriding Model ID for HF_TOKEN_ID")
+                    print(f"going to download tokenizer from HF for \"{hf_model_id}\"")
+                    self.tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
+                    print(f"successfully loaded the tokenizer using AutoTokenizer.from_pretrained from HF for \"{hf_model_id}\"")
+                else:
+                    print(f"going to download tokenizer from HF for \"{model_id}\"")
+                    self.tokenizer = AutoTokenizer.from_pretrained(model_id)
+                    print(f"successfully loaded the tokenizer using AutoTokenizer.from_pretrained from HF for \"{model_id}\"")
             except Exception as e:
-                print("exception while loading tokenizer from HuggingFace, exception={e}")
+                print(f"exception while loading tokenizer from HuggingFace, exception={e}")
                 print(f"no tokenizer provided, the {local_dir}, abs_path={abs_path} is empty, "
                       f"using default tokenizer i.e. {self.WORDS} words = {self.TOKENS} tokens")
                 self.tokenizer = None
@@ -476,4 +482,4 @@ class CustomTokenizer:
         else:
             return int(math.ceil((self.TOKENS/self.WORDS) * len(text.split())))
 
-_tokenizer = CustomTokenizer(globals.READ_BUCKET_NAME, globals.TOKENIZER_DIR_S3, globals.TOKENIZER, globals.TOKENIZER_MODEL_ID)
+_tokenizer = CustomTokenizer(globals.READ_BUCKET_NAME, globals.TOKENIZER_DIR_S3, globals.TOKENIZER, globals.TOKENIZER_MODEL_ID, globals.HF_TOKENIZER_MODEL_ID)


### PR DESCRIPTION
This adds a new config param, `hf_model_id` which downloads the tokenizer from huggingface directly overriding `model_id` if present


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
