### PR TITLE
HF token bug fix + docs update for copy s3 content command

### DIFF
--- a/docs/benchmarking_on_ec2.md
+++ b/docs/benchmarking_on_ec2.md
@@ -52,10 +52,11 @@ The steps for benchmarking on different types of EC2 instances (GPU/CPU/Neuron) 
     pip install -U fmbench
     ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    TMP_DIR="${1:-/tmp}"
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
@@ -159,10 +160,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
     ```
    - Now wait until the docker image is saved locally and then follow the instructions below to start a benchmarking test.
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    TMP_DIR="${1:-/tmp}"
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
@@ -263,10 +265,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
         sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
         ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    TMP_DIR="${1:-/tmp}"
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
@@ -359,10 +362,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
         sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=12g .
         ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    TMP_DIR="${1:-/tmp}"
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
@@ -432,10 +436,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
 
     ```
     
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    TMP_DIR="${1:-/tmp}"
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 

--- a/docs/benchmarking_on_ec2.md
+++ b/docs/benchmarking_on_ec2.md
@@ -55,12 +55,12 @@ The steps for benchmarking on different types of EC2 instances (GPU/CPU/Neuron) 
 1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory
     TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
-1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
+1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token. **Replace `/tmp` in the command below if you are using `/your-custom-tmp-directory` to store the config files and the `FMBench` generated data**.
 
     ```{.bash}
     echo hf_yourtokenstring > /tmp/fmbench-read/scripts/hf_token.txt
@@ -163,12 +163,12 @@ command below. The config file for this example can be viewed [here](src/fmbench
 1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory
     TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
-1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
+1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token. **Replace `/tmp` in the command below if you are using `/your-custom-tmp-directory` to store the config files and the `FMBench` generated data**.
 
     ```{.bash}
     echo hf_yourtokenstring > /tmp/fmbench-read/scripts/hf_token.txt
@@ -268,12 +268,12 @@ command below. The config file for this example can be viewed [here](src/fmbench
 1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory
     TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
-1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
+1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token. **Replace `/tmp` in the command below if you are using `/your-custom-tmp-directory` to store the config files and the `FMBench` generated data**.
 
     ```{.bash}
     echo hf_yourtokenstring > /tmp/fmbench-read/scripts/hf_token.txt
@@ -365,12 +365,12 @@ command below. The config file for this example can be viewed [here](src/fmbench
 1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory
     TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
-1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
+1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token. **Replace `/tmp` in the command below if you are using `/your-custom-tmp-directory` to store the config files and the `FMBench` generated data**.
 
     ```{.bash}
     echo hf_yourtokenstring > /tmp/fmbench-read/scripts/hf_token.txt
@@ -439,7 +439,7 @@ command below. The config file for this example can be viewed [here](src/fmbench
 1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. **Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory**.
 
     ```{.bash}
-    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory to store config files and other FMBench generated data
+    # Replace "/tmp" with "/your-custom-tmp-directory" if you want to use a custom tmp directory
     TMP_DIR="/tmp"
     curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```

--- a/docs/benchmarking_on_ec2.md
+++ b/docs/benchmarking_on_ec2.md
@@ -52,10 +52,11 @@ The steps for benchmarking on different types of EC2 instances (GPU/CPU/Neuron) 
     pip install -U fmbench
     ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
 
     ```{.bash}
-    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- /tmp
+    TMP_DIR="${1:-/tmp}"
+    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
 1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
@@ -158,10 +159,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
     ```
    - Now wait until the docker image is saved locally and then follow the instructions below to start a benchmarking test.
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
 
     ```{.bash}
-    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- /tmp
+    TMP_DIR="${1:-/tmp}"
+    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
 1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
@@ -261,10 +263,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
         sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
         ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
 
     ```{.bash}
-    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- /tmp
+    TMP_DIR="${1:-/tmp}"
+    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
 1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
@@ -356,10 +359,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
         sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=12g .
         ```
 
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
 
     ```{.bash}
-    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- /tmp
+    TMP_DIR="${1:-/tmp}"
+    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
 1. To download the model files from HuggingFace, create a `hf_token.txt` file in the `/tmp/fmbench-read/scripts/` directory containing the Hugging Face token you would like to use. In the command below replace the `hf_yourtokenstring` with your Hugging Face token.
@@ -428,10 +432,11 @@ command below. The config file for this example can be viewed [here](src/fmbench
 
     ```
     
-1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `/tmp` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory.
+1. Create local directory structure needed for `FMBench` and copy all publicly available dependencies from the AWS S3 bucket for `FMBench`. This is done by running the `copy_s3_content.sh` script available as part of the `FMBench` repo. Replace `"${1:-/tmp}"` in the command below with a different path if you want to store the config files and the `FMBench` generated data in a different directory. If not specified, it will default to the `\tmp` directory.
 
     ```{.bash}
-    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- /tmp
+    TMP_DIR="${1:-/tmp}"
+    curl -s https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/main/copy_s3_content.sh | sh -s -- "$TMP_DIR"
     ```
 
 

--- a/src/fmbench/1_generate_data.ipynb
+++ b/src/fmbench/1_generate_data.ipynb
@@ -200,17 +200,16 @@
    },
    "outputs": [],
    "source": [
-    "# HF token file name\n",
-    "hf_token_key: str = os.path.join(config['s3_read_data']['scripts_prefix'], \"hf_token.txt\")\n",
-    "hf_token_content: str = get_s3_object(config['s3_read_data']['read_bucket'], hf_token_key, decode=True)\n",
-    "\n",
-    "# Read the HF token. This HF token is requried while loading an HF dataset\n",
+    "# Read the HF token. This HF token is required while loading an HF dataset\n",
     "# if the HF token is not provided, an exception might be through at the dataset download step.\n",
     "try:\n",
+    "    # HF token file name\n",
+    "    hf_token_key: str = os.path.join(config['s3_read_data']['scripts_prefix'], \"hf_token.txt\")\n",
+    "    hf_token_content: str = get_s3_object(config['s3_read_data']['read_bucket'], hf_token_key, decode=True)\n",
     "    HF_TOKEN = hf_token_content.strip()\n",
     "    logger.info(f\"HF token provided by the user: {HF_TOKEN}\")\n",
     "except FileNotFoundError:\n",
-    "    logger.error(f\"HF token file not found at {HF_TOKEN_FNAME}\")\n",
+    "    logger.error(f\"HF token file not found.\")\n",
     "    HF_TOKEN = None"
    ]
   },

--- a/src/fmbench/1_generate_data.ipynb
+++ b/src/fmbench/1_generate_data.ipynb
@@ -204,12 +204,12 @@
     "# if the HF token is not provided, an exception might be through at the dataset download step.\n",
     "try:\n",
     "    # HF token file name\n",
-    "    hf_token_key: str = os.path.join(config['s3_read_data']['scripts_prefix'], \"hf_token.txt\")\n",
+    "    hf_token_key: str = os.path.join(config['s3_read_data']['scripts_prefix'], HF_TOKEN_FNAME)\n",
     "    hf_token_content: str = get_s3_object(config['s3_read_data']['read_bucket'], hf_token_key, decode=True)\n",
     "    HF_TOKEN = hf_token_content.strip()\n",
-    "    logger.info(f\"HF token provided by the user: {HF_TOKEN}\")\n",
+    "    logger.info(f\"HF toke file found: {HF_TOKEN_FNAME}\")\n",
     "except FileNotFoundError:\n",
-    "    logger.error(f\"HF token file not found.\")\n",
+    "    logger.error(f\"HF token file '{HF_TOKEN_FNAME}' not found.\")\n",
     "    HF_TOKEN = None"
    ]
   },

--- a/src/fmbench/globals.py
+++ b/src/fmbench/globals.py
@@ -212,6 +212,9 @@ if eval_config is not None:
 METADATA_DIR:str = config['dir_paths']['metadata_dir']
 METRICS_PATH_FNAME: str = "metrics_path.txt"
 
+# Name of the .txt file where the HF token is stored
+HF_TOKEN_FNAME: str = "hf_token.txt"
+
 DIR_LIST = [DATA_DIR, PROMPTS_DIR, METRICS_DIR, MODELS_DIR, METRICS_PER_INFERENCE_DIR, METRICS_PER_CHUNK_DIR]
 
 # this is for custom tokenizers


### PR DESCRIPTION
This file contains the following changes:

1. Bug fix for reading the HF token in the generate_data notebook
2. Command update for copy s3 content to set "TMP_DIR" as the shell variable and if not, it sets the tmp directory by default to \tmp
