### PR TITLE
Update Fallback Pricing YAML Path

### DIFF
--- a/src/fmbench/globals.py
+++ b/src/fmbench/globals.py
@@ -26,7 +26,7 @@ current_working_directory: str = Path.cwd()
 
 CONFIG_FILEPATH_FILE: str = current_working_directory / 'config_filepath.txt'
 
-PRICING_FALLBACK_YAML_PATH="https://github.com/aws-samples/foundation-model-benchmarking-tool/blob/main/src/fmbench/configs/pricing.yml"
+PRICING_FALLBACK_YAML_PATH="https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/refs/heads/main/src/fmbench/configs/pricing_fallback.yml"
 
 # S3 client initialization
 s3_client = boto3.client('s3')


### PR DESCRIPTION
Fallback pricing Path was incorrectly configured to use old pricing.yaml, this update fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
