### PR TITLE
llama3.2 1b g6e.2xl config file for smaller prompts

### DIFF
--- a/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
+++ b/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
@@ -121,7 +121,7 @@ inference_parameters:
     temperature: 0.1
     top_p: 0.92
     top_k: 120  
-    max_new_tokens: 10
+    max_new_tokens: 15
     Content-type: application/json
     return_full_text: False
 

--- a/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
+++ b/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
@@ -1,0 +1,206 @@
+
+# config file for a rest endpoint supported on fmbench - 
+# this file uses a llama-3-8b-chat-hf deployed on ec2
+general:
+  name: "llama3.2-1b-g6e.2xl-tp=1-mc=max-djl-ec2"      
+  model_name: "Meta-Llama-3.2-8B-Instruct"
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  - 500_token_prompts_synthetic_data.jsonl
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: llama3_2_tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_llama3.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: yes
+  3_run_inference.ipynb: yes
+  4_model_metric_analysis.ipynb: yes
+  5_cleanup.ipynb: yes
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 1100
+    payload_file: payload_en_1-1100.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_1-1100
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  ec2_djl:
+    do_sample: yes
+    temperature: 0.1
+    top_p: 0.92
+    top_k: 120  
+    max_new_tokens: 20
+    Content-type: application/json
+    return_full_text: False
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: "Meta-Llama-3.2-1b-Instruct"
+    # AWS region, this parameter is templatized, no need to change
+    region: {region}
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    #from huggingface to grab
+    model_id:meta-llama/Llama-3.2-1b-Instruct # model id, version and image uri not needed for byo endpoint
+    model_version:
+    model_name: "llama3.2-1b-instruct"
+    # this can be changed to the IP address of your specific EC2 instance where the model is hosted
+    ep_name: 'http://127.0.0.1:8080/invocations' 
+    instance_type: "g6e.2xlarge"
+    image_uri: 763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.29.0-lmi11.0.0-cu124
+    deploy: yes #setting to yes to run deployment script for ec2
+    instance_count: 
+    deployment_script: ec2_deploy.py
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example for a rest DJL predictor
+    # for a llama3-8b-instruct deployed on ec2
+    inference_script: ec2_predictor.py
+    # This section defines the settings for Amazon EC2 instances
+    ec2:
+      # The following line specifies the runtime and GPU settings for the instance
+      # '--runtime=nvidia' tells the container runtime to use the NVIDIA runtime
+      # '--gpus all' makes all GPUs available to the container
+      # '--shm-size 12g' sets the size of the shared memory to 12 gigabytes
+      gpu_or_neuron_setting: --gpus all --shm-size 12g
+      #This setting specifies the timeout (in seconds) for loading the model. In this case, the timeout is set to 2400 seconds, which is 40 minutes. 
+      # If the model takes longer than 40 minutes to load, the process will time out and fail.
+      model_loading_timeout: 2400
+    inference_spec:
+      # this should match one of the sections in the inference_parameters section above
+      parameter_set: ec2_djl
+      tp_degree: 1
+      shm_size: 12g
+      model_loading_timeout: 2400
+      model_copies: max
+    # modify the serving properties to match your model and requirements
+    serving.properties: |
+      engine=MPI
+      option.tensor_parallel_degree=1
+      option.max_rolling_batch_size=256
+      option.model_id=meta-llama/Llama-3.2-1b-Instruct
+      option.rolling_batch=lmi-dist
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-1100.jsonl
+
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+
+report:
+  latency_budget: 0.1
+  cost_per_10k_txn_budget: 50
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025  

--- a/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
+++ b/src/fmbench/configs/llama3.2/1b/config-llama3.2-1b-g6e.2xl-tp-1-mc-max-djl.yml
@@ -121,7 +121,7 @@ inference_parameters:
     temperature: 0.1
     top_p: 0.92
     top_k: 120  
-    max_new_tokens: 20
+    max_new_tokens: 10
     Content-type: application/json
     return_full_text: False
 
@@ -138,7 +138,7 @@ experiments:
     # if deploying directly from HuggingFace this would be a HuggingFace model id
     # see the DJL serving deployment script in the code repo for reference. 
     #from huggingface to grab
-    model_id:meta-llama/Llama-3.2-1b-Instruct # model id, version and image uri not needed for byo endpoint
+    model_id: meta-llama/Llama-3.2-1b-Instruct # model id, version and image uri not needed for byo endpoint
     model_version:
     model_name: "llama3.2-1b-instruct"
     # this can be changed to the IP address of your specific EC2 instance where the model is hosted


### PR DESCRIPTION
This PR contains a config file for llama3.2 1b on a g6e.2xl instance using smaller prompts with synthetic data with max new tokens set to 15.