### PR TITLE
chore: improve no latency metrics data available messaging

### DIFF
--- a/src/fmbench/5_model_metric_analysis.ipynb
+++ b/src/fmbench/5_model_metric_analysis.ipynb
@@ -2367,7 +2367,7 @@
     "df_summary_latency_metrics_dataset = df_summary_metrics_dataset[\n",
     "    latency_index_cols + latency_cols\n",
     "]\n",
-    "latency_metrics_table = \"_No token latency metrics data is available. To get token latency metrics enable streaming responses by setting `stream: True` in experiment configuration_.\"\n",
+    "latency_metrics_table = \"_No token latency metrics data are available. To get token latency metrics, ensure your inference endpoint allows streaming responses, and enable streaming responses by setting `stream: True` in experiment configuration_.\"\n",
     "if \"TTFT_p50\" in df_summary_latency_metrics_dataset.columns:\n",
     "    if all(df_summary_latency_metrics_dataset.TTFT_p50.isnull()):\n",
     "        logger.info(\n",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Improve messaging for if latency metrics data is not available. The inference endpoint must allow for streaming responses in order to use `stream: True` in the experiment config, otherwise the latency metrics table will not work.
