### PR TITLE
pricing fallback bug fix

### DIFF
--- a/fmbench/globals.py
+++ b/fmbench/globals.py
@@ -30,7 +30,7 @@ current_working_directory: str = Path.cwd()
 
 CONFIG_FILEPATH_FILE: str = current_working_directory / 'config_filepath.txt'
 
-PRICING_FALLBACK_YAML_PATH="https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/refs/heads/main/src/fmbench/configs/pricing_fallback.yml"
+PRICING_FALLBACK_YAML_PATH="https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/refs/heads/main/fmbench/configs/pricing_fallback.yml"
 
 # S3 client initialization
 s3_client = boto3.client('s3')


### PR DESCRIPTION
Changing the raw url to the pricing yaml in globals.py to point to the correct path after the latest release.
