### PR TITLE
Custom predictor: Taking a Ollama Custom Server for TinyLlama 1.1b for example

### DIFF
--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
@@ -1,4 +1,6 @@
 # config file for a rest endpoint supported on fmbench - 
+# To run this configuration file, follow the steps here to deploy
+# the model first: https://github.com/madhurprash/EC2_tinyllama
 general:
   name: "byo-REST-ep-tinyllama-ollama"      
   model_name: "tinyllama-ollama"
@@ -168,7 +170,7 @@ experiments:
     # in this case, we use ray serve with `NousResearch/Llama-2-13b-chat-hf` model deployed on an EKS cluster.
     # the endpoint url format used in this example is "http://<NLB_DNS_NAME>/serve/infer?sentence=<PROMPT_PAYLOAD>"
     ep_name: 'http://localhost:8080/v2/completions' # public DNS/URL to send your request
-    instance_type: "<your-instance-type>"
+    instance_type: "g6e.xlarge"
     image_uri:
     deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
     # FMBench comes packaged with multiple deployment scripts, such as scripts for JumpStart
@@ -187,9 +189,9 @@ experiments:
       # This parameter is specified above with custom configurations
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
-      model_id: "tinyllama"
+      model_id: "tinyllama:1.1b"
       headers:
-        custom_authentication_token: "madhurauth"  # Replace with actual token
+        custom_authentication_token: "your-secret-token-here"  # Replace with actual token
         content-type: "application/json"
     # runs are done for each combination of payload file and concurrency level
     payload_files:

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
@@ -190,6 +190,9 @@ experiments:
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
       model_id: "tinyllama"
+      # All key-value pairs added in this headers section are transparently
+      # passed via the POST request to the model server. You can add any custom
+      # header parameters needed for your specific implementation.
       headers:
         custom_authentication_token: "your-secret-token-here"  # Replace with actual token
         content-type: "application/json"

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
@@ -189,7 +189,7 @@ experiments:
       # This parameter is specified above with custom configurations
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
-      model_id: "tinyllama:1.1b"
+      model_id: "tinyllama"
       headers:
         custom_authentication_token: "your-secret-token-here"  # Replace with actual token
         content-type: "application/json"

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor-tinyllama.yml
@@ -1,0 +1,216 @@
+# config file for a rest endpoint supported on fmbench - 
+general:
+  name: "byo-REST-ep-tinyllama-ollama"      
+  model_name: "tinyllama-ollama"
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  # Format: hf:dataset-id/subset-name/split-name. Use   "default" if no subset name is provided.
+  - hf:THUDM/LongBench/2wikimqa_e/test
+  - hf:THUDM/LongBench/2wikimqa/test
+  - hf:THUDM/LongBench/hotpotqa_e/test
+  - hf:THUDM/LongBench/hotpotqa/test
+  - hf:THUDM/LongBench/narrativeqa/test
+  - hf:THUDM/LongBench/triviaqa_e/test
+  - hf:THUDM/LongBench/triviaqa/test
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_llama3.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: yes
+  3_run_inference.ipynb: yes
+  4_get_evaluations.ipynb: yes
+  5_model_metric_analysis.ipynb: yes
+  6_cleanup.ipynb: no
+
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  ground_truth_col_key: answers
+  question_col_key: input
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 500
+    payload_file: payload_en_1-500.jsonl
+  - language: en
+    min_length_in_tokens: 500
+    max_length_in_tokens: 1000
+    payload_file: payload_en_500-1000.jsonl
+  - language: en
+    min_length_in_tokens: 1000
+    max_length_in_tokens: 2000
+    payload_file: payload_en_1000-2000.jsonl
+  - language: en
+    min_length_in_tokens: 2000
+    max_length_in_tokens: 3000
+    payload_file: payload_en_2000-3000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 4000
+    payload_file: payload_en_3000-4000.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_1-500
+
+# name of the file that contains the model evaluation information
+# for example, the prompt template names, the ground truth column name (if any), 
+# LLM panelist information, inference parameters, etc.
+model_evaluations: model_eval_all_info.yml
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: custom_pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  custom_rest:
+    temperature: 0.3
+    top_p: 0.3
+    stream: False
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: "custom-model-byoe"
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    model_id: # model id, version and image uri not needed for byo endpoint
+    hf_tokenizer_model_id: 
+    model_version:
+    model_name: "custom-model"
+    # the ep_name will contain the endpoint url that is used to invoke your model and get the response
+    # in this case, we use ray serve with `NousResearch/Llama-2-13b-chat-hf` model deployed on an EKS cluster.
+    # the endpoint url format used in this example is "http://<NLB_DNS_NAME>/serve/infer?sentence=<PROMPT_PAYLOAD>"
+    ep_name: 'http://localhost:8080/v2/completions' # public DNS/URL to send your request
+    instance_type: "<your-instance-type>"
+    image_uri:
+    deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
+    # FMBench comes packaged with multiple deployment scripts, such as scripts for JumpStart
+    # scripts for deploying using DJL DeepSpeed, tensorRT etc. You can also add your own.
+    # See repo for details
+    instance_count: 
+    deployment_script: 
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example of a custom rest predictor
+    # that does a POST request on the endpoint URL (given on line 164) with custom headers, 
+    # parameters and authentication information
+    inference_script: custom_rest_predictor.py
+    # This is the inference spec with custom information. You can add/remove variables 
+    # and access those in the predictor file to use them as accepted by your container.
+    inference_spec:
+      # This parameter is specified above with custom configurations
+      parameter_set: custom_rest
+      # This model id is appended to the prompt as the payload is sent to the model id
+      model_id: "tinyllama"
+      headers:
+        custom_authentication_token: "madhurauth"  # Replace with actual token
+        content-type: "application/json"
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-500.jsonl
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+
+report:
+  latency_budget: 5
+  cost_per_10k_txn_budget: 50
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025
+
+

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
@@ -68,7 +68,7 @@ s3_read_data:
 
   # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
   # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
-  prompt_template_file: prompt_template_custom.txt
+  prompt_template_file: prompt_template_llama3.txt
 
 # steps to run, usually all of these would be
 # set to yes so nothing needs to change here
@@ -78,7 +78,7 @@ s3_read_data:
 run_steps:
   0_setup.ipynb: yes
   1_generate_data.ipynb: yes
-  2_deploy_model.ipynb: no
+  2_deploy_model.ipynb: yes
   3_run_inference.ipynb: yes
   4_get_evaluations.ipynb: yes
   5_model_metric_analysis.ipynb: yes
@@ -90,6 +90,8 @@ datasets:
   prompt_template_keys:
   - input
   - context
+  ground_truth_col_key: answers
+  question_col_key: input
   # if your dataset has multiple languages and it has a language
   # field then you could filter it for a language. Similarly,
   # you can filter your dataset to only keep prompts between
@@ -124,7 +126,12 @@ datasets:
 # the price:performance analysis is only done for 1
 # dataset which is listed below as the dataset_of_interest
 metrics:
-  dataset_of_interest: en_3000-4000
+  dataset_of_interest: en_1-500
+
+# name of the file that contains the model evaluation information
+# for example, the prompt template names, the ground truth column name (if any), 
+# LLM panelist information, inference parameters, etc.
+model_evaluations: model_eval_all_info.yml
   
 # all pricing information is in the pricing.yml file
 # this file is provided in the repo. You can add entries
@@ -161,7 +168,7 @@ experiments:
     # the ep_name will contain the endpoint url that is used to invoke your model and get the response
     # in this case, we use ray serve with `NousResearch/Llama-2-13b-chat-hf` model deployed on an EKS cluster.
     # the endpoint url format used in this example is "http://<NLB_DNS_NAME>/serve/infer?sentence=<PROMPT_PAYLOAD>"
-    ep_name: 'https://<domain-name>/v2/completions' # public DNS/URL to send your request
+    ep_name: '<your-ep-url>' # public DNS/URL to send your request
     instance_type: "<your-instance-type>"
     image_uri:
     deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
@@ -181,24 +188,19 @@ experiments:
       # This parameter is specified above with custom configurations
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
-      model_id: "custom-model-id"
+      model_id: "<custom-model>"
       headers:
-        custom_client_id: "<your-custom-client-id-here>"
-        custom_authentication_token: "<place-your-custom-auth-token-here>"  # Replace with actual token
+        custom_client_id: <your-custom-client-id>
+        custom_authentication_token: "<your-auth-token>"  # Replace with actual token
         content-type: "application/json"
-      generation_config:
-        temperature: 0.1
-        top_p: 0.92
     # runs are done for each combination of payload file and concurrency level
     payload_files:
-    - payload_en_1-924.jsonl
+    - payload_en_1-500.jsonl
     # concurrency level refers to number of requests sent in parallel to an endpoint
     # the next set of requests is sent once responses for all concurrent requests have
     # been received.
     concurrency_levels:
     - 1
-    - 2
-    - 4
     # Environment variables to be passed to the container
     # this is not a fixed list, you can add more parameters as applicable.
     env:

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
@@ -1,0 +1,216 @@
+# config file for a rest endpoint supported on fmbench - 
+# this file uses a llama-2-13b-chat-hf deployed on an EKS cluster using ray serve
+general:
+  name: "byo-REST-ep"      
+  model_name: "custom-model"
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  # Format: hf:dataset-id/subset-name/split-name. Use   "default" if no subset name is provided.
+  - hf:THUDM/LongBench/2wikimqa_e/test
+  - hf:THUDM/LongBench/2wikimqa/test
+  - hf:THUDM/LongBench/hotpotqa_e/test
+  - hf:THUDM/LongBench/hotpotqa/test
+  - hf:THUDM/LongBench/narrativeqa/test
+  - hf:THUDM/LongBench/triviaqa_e/test
+  - hf:THUDM/LongBench/triviaqa/test
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_custom.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: no
+  3_run_inference.ipynb: yes
+  4_get_evaluations.ipynb: yes
+  5_model_metric_analysis.ipynb: yes
+  6_cleanup.ipynb: no
+
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 500
+    payload_file: payload_en_1-500.jsonl
+  - language: en
+    min_length_in_tokens: 500
+    max_length_in_tokens: 1000
+    payload_file: payload_en_500-1000.jsonl
+  - language: en
+    min_length_in_tokens: 1000
+    max_length_in_tokens: 2000
+    payload_file: payload_en_1000-2000.jsonl
+  - language: en
+    min_length_in_tokens: 2000
+    max_length_in_tokens: 3000
+    payload_file: payload_en_2000-3000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 4000
+    payload_file: payload_en_3000-4000.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_3000-4000
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: custom_pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  custom_rest:
+    generation_config:
+      temperature: 0.3
+      top_p: 0.3
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: "custom-model-byoe"
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    model_id: # model id, version and image uri not needed for byo endpoint
+    hf_tokenizer_model_id: 
+    model_version:
+    model_name: "custom-model"
+    # the ep_name will contain the endpoint url that is used to invoke your model and get the response
+    # in this case, we use ray serve with `NousResearch/Llama-2-13b-chat-hf` model deployed on an EKS cluster.
+    # the endpoint url format used in this example is "http://<NLB_DNS_NAME>/serve/infer?sentence=<PROMPT_PAYLOAD>"
+    ep_name: 'https://<domain-name>/v2/completions' # public DNS/URL to send your request
+    instance_type: "<your-instance-type>"
+    image_uri:
+    deploy: no #setting to no since the endpoint has already been deployed on an EKS cluster
+    # FMBench comes packaged with multiple deployment scripts, such as scripts for JumpStart
+    # scripts for deploying using DJL DeepSpeed, tensorRT etc. You can also add your own.
+    # See repo for details
+    instance_count: 
+    deployment_script: 
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example of a custom rest predictor
+    # that does a POST request on the endpoint URL (given on line 164) with custom headers, 
+    # parameters and authentication information
+    inference_script: custom_rest_predictor.py
+    # This is the inference spec with custom information. You can add/remove variables 
+    # and access those in the predictor file to use them as accepted by your container.
+    inference_spec:
+      # This parameter is specified above with custom configurations
+      parameter_set: custom_rest
+      # This model id is appended to the prompt as the payload is sent to the model id
+      model_id: "custom-model-id"
+      headers:
+        custom_client_id: "<your-custom-client-id-here>"
+        custom_authentication_token: "<place-your-custom-auth-token-here>"  # Replace with actual token
+        content-type: "application/json"
+      generation_config:
+        temperature: 0.1
+        top_p: 0.92
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-924.jsonl
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    - 2
+    - 4
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+
+report:
+  latency_budget: 5
+  cost_per_10k_txn_budget: 50
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025
+
+

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
@@ -1,10 +1,15 @@
-# config file for a rest endpoint supported on fmbench - 
-# this file uses a llama-2-13b-chat-hf deployed on an EKS cluster using ray serve
+# config file for a rest endpoint supported on fmbench -
+# This config file uses custom payload functionalities, and points to 
+# a "custom_rest_predictor.py" that does a request.post to an endpoint
+# url, with the model id, inference parameters and a few headers configured
+# within this config file
 general:
-  name: "byo-REST-ep"      
-  model_name: "custom-model"
+  name: "<add-your-rest-ep-model-name-here>"      
+  model_name: "<your-custom-model-name>"
   
 # AWS and SageMaker settings
+# These are placeholder values that will be substituted
+# dynamically once FMBench runs the test
 aws:
   # AWS region, this parameter is templatized, no need to change
   region: {region}
@@ -14,6 +19,9 @@ aws:
   bucket: {write_bucket} ## add the name of your desired bucket
 
 # directory paths in the write bucket, no need to change these
+# These directory paths point to the data, prompts, metrics and other
+# model and metadata information that will be stored in the FMBench write
+# bucket once the benchmarking test starts
 dir_paths:
   data_prefix: data
   prompts_prefix: prompts
@@ -41,13 +49,28 @@ s3_read_data:
   configs_prefix: configs
 
   # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  # Add your custom pricing in this yml file which is located at "configs/pricing.yml" that contains
+  # instance hourly and token-based pricing. NOTE: The instance_type parameter in this config file should match
+  # the instance_type parameter in the pricing.yml file for FMBench to correctly map the values before
+  # calculating the cost to run and evaluate the models to be benchmarked.
   config_files:
   - pricing.yml
 
   # S3 prefix for the dataset files
   source_data_prefix: source_data
-  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  
+  # FOR HUGGING FACE DATASETS:
+  # ---------------------------
+  # FMBench now supports benchmarking models using datasets from Hugging Face with a simplified prefixing method. 
+  # To specify a Hugging Face dataset and its split, use the hf: prefix followed by the dataset identifier, subset name, and split name. 
+  # If a subset name is not provided, it defaults to default. If a split name is not provided, FMBench automatically selects the next available split at runtime.
+  # FOR CUSTOM DATASETS:
+  # ---------------------------
+  # To use custom data, convert it into JSONL format. We provide a sample notebook to help convert Hugging Face or custom datasets into JSONL and upload them to an S3 bucket used by FMBench. 
+  # Follow the steps in the https://github.com/aws-samples/foundation-model-benchmarking-tool/blob/main/fmbench/bring_your_own_dataset.ipynb notebook to integrate your own dataset into FMBench. 
+  # Place this JSONL file in the local fmbench-read/scripts directory in your FMBench EC2 instance or in the fmbench-read S3 bucket in the scripts directory.
   source_data_files:
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
   # Format: hf:dataset-id/subset-name/split-name. Use   "default" if no subset name is provided.
   - hf:THUDM/LongBench/2wikimqa_e/test
   - hf:THUDM/LongBench/2wikimqa/test
@@ -63,12 +86,13 @@ s3_read_data:
   #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
   tokenizer_prefix: tokenizer
 
-  # S3 prefix for prompt templates
+  # S3 prefix for prompt templates - this does not have to be changed
   prompt_template_dir: prompt_template
 
   # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
   # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
-  prompt_template_file: prompt_template_llama3.txt
+  # If you have a custom prompt template, place the file in the local fmbench-read/scripts directory and point to it here
+  prompt_template_file: <your-prompt-template.txt>
 
 # steps to run, usually all of these would be
 # set to yes so nothing needs to change here
@@ -88,8 +112,12 @@ run_steps:
 datasets:
   # dataset related configuration
   prompt_template_keys:
+  # <replace with the keys in your dataset. If your dataset contains another key you want inputted into the prompt, then specify that here and it will
+  # be plugged into the prompt
   - input
   - context
+  # If you want to measure model accuracy, mention the column keys in the dataset that point to the question/task and the ground truth. 
+  # This will be used by FMBench's LLM evaluators to evaluate the correctness of models to be benchmarked.
   ground_truth_col_key: answers
   question_col_key: input
   # if your dataset has multiple languages and it has a language
@@ -156,7 +184,7 @@ inference_parameters:
 # but different instance types, or different models, or even different hosting
 # options.
 experiments:
-  - name: "custom-model-byoe"
+  - name: "<your-model-name>"
     # model_id is interpreted in conjunction with the deployment_script, so if you
     # use a JumpStart model id then set the deployment_script to jumpstart.py.
     # if deploying directly from HuggingFace this would be a HuggingFace model id
@@ -164,7 +192,7 @@ experiments:
     model_id: # model id, version and image uri not needed for byo endpoint
     hf_tokenizer_model_id: 
     model_version:
-    model_name: "custom-model"
+    model_name: "<your-model-name>"
     # the ep_name will contain the endpoint url that is used to invoke your model and get the response
     # in this case, we use ray serve with `NousResearch/Llama-2-13b-chat-hf` model deployed on an EKS cluster.
     # the endpoint url format used in this example is "http://<NLB_DNS_NAME>/serve/infer?sentence=<PROMPT_PAYLOAD>"
@@ -176,7 +204,7 @@ experiments:
     # scripts for deploying using DJL DeepSpeed, tensorRT etc. You can also add your own.
     # See repo for details
     instance_count: 
-    deployment_script: 
+    deployment_script: # No deployment script is needed since this is a byoe configuration file
     # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
     # and Bedrock. You can also add your own. This is an example of a custom rest predictor
     # that does a POST request on the endpoint URL (given on line 164) with custom headers, 
@@ -188,7 +216,7 @@ experiments:
       # This parameter is specified above with custom configurations
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
-      model_id: "<custom-model>"
+      model_id: "<custom-model-id>"
       headers:
         custom_client_id: <your-custom-client-id>
         custom_authentication_token: "<your-auth-token>"  # Replace with actual token

--- a/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
+++ b/fmbench/configs/byoe/config-byo-custom-rest-predictor.yml
@@ -217,6 +217,9 @@ experiments:
       parameter_set: custom_rest
       # This model id is appended to the prompt as the payload is sent to the model id
       model_id: "<custom-model-id>"
+      # All key-value pairs added in this headers section are transparently
+      # passed via the POST request to the model server. You can add any custom
+      # header parameters needed for your specific implementation.
       headers:
         custom_client_id: <your-custom-client-id>
         custom_authentication_token: "<your-auth-token>"  # Replace with actual token

--- a/fmbench/scripts/custom_rest_predictor.py
+++ b/fmbench/scripts/custom_rest_predictor.py
@@ -50,16 +50,23 @@ class CustomRestPredictor(FMBenchPredictor):
         try:
             # define the generation config, custom headers and model id from the inference spec
             # that will be used in the payload while FMBench makes predictions on the model endpoint
-            generation_config = self._inference_spec.get("parameters", {}).get("generation_config", {})
-            headers = self._inference_spec.get("headers", {})
+            inference_param_set = self._inference_spec.get("parameters")
+            headers = self._inference_spec.get("headers")
             model_id = self._inference_spec.get("model_id")
             # Prepare the request body - in this request body, we are providing the generation config, prompt
             # and the model id as given in the inference spec within the FMBench config file
-            request_body = {
-                "model_id": model_id,
-                "prompt": payload['inputs'],
-                "generation_config": generation_config
-            }
+            if inference_param_set:
+                request_body = {
+                    "model_id": model_id,
+                    "prompt": payload['inputs'],
+                } | inference_param_set
+            else:
+                logger.info(f"Using the request body without the generation_config variable")
+                request_body = {
+                    "model_id": model_id,
+                    "prompt": payload['inputs']
+                }
+                
             prompt_tokens = count_tokens(payload["inputs"])
             # Start the timer to measure the latency of the prediction made to the endpoint
             st = time.perf_counter()

--- a/fmbench/scripts/custom_rest_predictor.py
+++ b/fmbench/scripts/custom_rest_predictor.py
@@ -1,0 +1,152 @@
+import os
+import json
+import math
+import time
+import boto3
+import logging
+import requests
+import pandas as pd
+from datetime import datetime
+from fmbench.scripts import constants
+from fmbench.utils import count_tokens
+from typing import Dict, Optional, List
+from fmbench.scripts.fmbench_predictor import (FMBenchPredictor,
+                                               FMBenchPredictionResponse)
+
+# set a logger
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class CustomRestPredictor(FMBenchPredictor):
+    """
+    This is a custom rest predictor that does a POST request on the endpoint
+    specified in the configuration file with custom headers, authentication parameters
+    and the model_id.
+    """
+    def __init__(self,
+                 endpoint_name: str,
+                 inference_spec: Optional[Dict],
+                 metadata: Optional[Dict]):
+        try:
+            self._endpoint_name: str = endpoint_name
+            self._inference_spec: Dict = inference_spec 
+        except Exception as e:
+            logger.error(f"create_predictor, exception occured while creating predictor "
+                         f"for endpoint_name={self._endpoint_name}, exception={e}")
+        logger.info(f"_endpoint_name={self._endpoint_name}, _inference_spec={self._inference_spec}")
+
+    def get_prediction(self, payload: Dict) -> FMBenchPredictionResponse:
+        # Initialize some variables, including the response, latency, streaming variables, prompt and completion tokens.
+        response_json: Optional[Dict] = None
+        response: Optional[str] = None
+        latency: Optional[float] = None
+        TTFT: Optional[float] = None
+        TPOT: Optional[float] = None
+        TTLT: Optional[float] = None
+        prompt_tokens: Optional[int] = None
+        completion_tokens: Optional[int] = None
+        generated_text: Optional[str] = None
+        
+        try:
+            # define the generation config, custom headers and model id from the inference spec
+            # that will be used in the payload while FMBench makes predictions on the model endpoint
+            generation_config = self._inference_spec.get("parameters", {}).get("generation_config", {})
+            headers = self._inference_spec.get("headers", {})
+            model_id = self._inference_spec.get("model_id")
+            # Prepare the request body - in this request body, we are providing the generation config, prompt
+            # and the model id as given in the inference spec within the FMBench config file
+            request_body = {
+                "model_id": model_id,
+                "prompt": payload['inputs'],
+                "generation_config": generation_config
+            }
+            prompt_tokens = count_tokens(payload["inputs"])
+            # Start the timer to measure the latency of the prediction made to the endpoint
+            st = time.perf_counter()
+            # Make POST request including the headers, the request body, and the endpoint url.
+            response = requests.post(
+                self._endpoint_name,
+                headers=headers,
+                json=request_body
+            )
+            # measure the total latency to make the POST request to the endpoint
+            latency = time.perf_counter() - st
+            response.raise_for_status()
+            response_data = response.json()
+            # Extract the generated text from the completions array
+            if response_data.get("completions"):
+                generated_text = response_data["completions"][0].get("text", "")
+            response_json = dict(generated_text=generated_text)
+            # Get completion tokens from the usage information if available
+            # otherwise fall back to counting tokens
+            if response_data.get("usage"):
+                completion_tokens = response_data["usage"].get("completion_tokens")
+                prompt_tokens = response_data["usage"].get("prompt_tokens")
+            else:
+                completion_tokens = count_tokens(generated_text) 
+        except requests.exceptions.RequestException as e:
+            logger.error(f"get_prediction, exception occurred while getting prediction for payload={payload} "
+                        f"from predictor={self._endpoint_name}, response={response}, exception={e}")
+        return FMBenchPredictionResponse(
+            response_json=response_json,
+            latency=latency,
+            time_to_first_token=TTFT,
+            time_per_output_token=TPOT,
+            time_to_last_token=TTLT,
+            completion_tokens=completion_tokens,
+            prompt_tokens=prompt_tokens
+        )
+        
+    @property
+    def endpoint_name(self) -> str:
+        """The endpoint name property."""
+        return self._endpoint_name
+
+    # The rest ep is deployed on an instance that incurs hourly cost hence, the calculcate cost function
+    # computes the cost of the experiment on an hourly basis. If your instance has a different pricing structure
+    # modify this function.
+    def calculate_cost(self,
+                       instance_type: str,
+                       instance_count: int,
+                       pricing: Dict,
+                       duration: float,
+                       prompt_tokens: int,
+                       completion_tokens: int) -> float:
+        """Calculate the cost of each experiment run."""
+        experiment_cost: Optional[float] = None
+        try:
+            instance_based_pricing = pricing['pricing']['instance_based']
+            hourly_rate = instance_based_pricing.get(instance_type, None)
+            logger.info(f"the hourly rate for running on {instance_type} is {hourly_rate}, instance_count={instance_count}")
+            # calculating the experiment cost for instance based pricing
+            instance_count = instance_count if instance_count else 1
+            experiment_cost = (hourly_rate / 3600) * duration * instance_count
+        except Exception as e:
+            logger.error(f"exception occurred during experiment cost calculation, exception={e}")
+        return experiment_cost
+    
+    def get_metrics(self,
+                    start_time: datetime,
+                    end_time: datetime,
+                    period: int = 60) -> pd.DataFrame:
+        # not implemented
+        return None
+
+    def shutdown(self) -> None:
+        """Represents the function to shutdown the predictor
+           cleanup the endpooint/container/other resources
+        """
+        return None
+    
+    @property
+    def inference_parameters(self) -> Dict:
+        """The inference parameters property."""
+        return self._inference_spec.get("parameters")
+
+    @property
+    def platform_type(self) -> Dict:
+        """The inference parameters property."""
+        return constants.PLATFORM_EXTERNAL
+    
+def create_predictor(endpoint_name: str, inference_spec: Optional[Dict], metadata: Optional[Dict]):
+    return CustomRestPredictor(endpoint_name, inference_spec, metadata)


### PR DESCRIPTION
This PR contains the following additions:

1. Adding a base config file and the custom predictor for the config file. This custom predictor is based on a custom payload.
2. Adding a TinyLlama1.1b byoe file using the same custom response and payload format. Adding instructions to deploy the model here: https://github.com/madhurprash/EC2_tinyllama/tree/main, tested on the custom predictor.
3. Comments throughout the config files.
