### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
    "transformers>=4.48.1",
    "twine>=6.1.0",
    "typing-extensions>=4.12.2",
-   "vllm>=0.6.6.post1",
    "zmq>=0.0.0",
 ]
 


### PR DESCRIPTION
Removed vllm from pyproject.toml as we use docker containers now


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
